### PR TITLE
added possibility to enable swiping on vertical / horizontal axis only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.1]
+
+- Add option to disable vertical or horizontal swipping
+
 ## [1.2.0]
 
 - Allow changing the scale of the card that is behind the front card

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ class Example extends StatelessWidget {
 | threshold | 50     |    Threshold from which the card is swiped away | false
 | scale | 0.9     |    Scale of the card that is behind the front card | false
 | isDisabled | false      |   Set to ```true``` if swiping should be disabled, has no impact when triggered from the outside | false
+| isHorizontalSwipingEnabled | true    |   Set to ```false``` if you want your card to move only across the vertical axis when swiping
+| isVerticalSwipingEnabled | true    |   Set to ```false``` if you want your card to move only across the horizontal axis when swiping
 | onTapDisabled | -     |    Function that get triggered when the swiper is disabled | false
 | onSwipe | -    |    Called with the new index and detected swipe direction when the user swiped | false
 | onEnd | -    |    Called when there is no Widget left to be swiped away | false

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.2.1"
   js:
     dependency: transitive
     description:

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -42,6 +42,12 @@ class CardSwiper extends StatefulWidget {
   /// direction in which the card gets swiped when triggered by controller, default set to right
   final CardSwiperDirection direction;
 
+  /// set to false if you want your card to move only across the vertical axis when swiping
+  final bool isHorizontalSwipingEnabled;
+
+  /// set to false if you want your card to move only across the horizontal axis when swiping
+  final bool isVerticalSwipingEnabled;
+
   const CardSwiper({
     Key? key,
     required this.cards,
@@ -56,6 +62,8 @@ class CardSwiper extends StatefulWidget {
     this.onSwipe,
     this.onEnd,
     this.direction = CardSwiperDirection.right,
+    this.isHorizontalSwipingEnabled = true,
+    this.isVerticalSwipingEnabled = true,
   })  : assert(
           maxAngle >= 0 && maxAngle <= 360,
           'maxAngle must be between 0 and 360',
@@ -177,8 +185,12 @@ class _CardSwiperState extends State<CardSwiper>
         onPanUpdate: (tapInfo) {
           if (!widget.isDisabled) {
             setState(() {
-              _left += tapInfo.delta.dx;
-              _top += tapInfo.delta.dy;
+              if (widget.isHorizontalSwipingEnabled) {
+                _left += tapInfo.delta.dx;
+              }
+              if (widget.isVerticalSwipingEnabled) {
+                _top += tapInfo.delta.dy;
+              }
               _total = _left + _top;
               _calculateAngle();
               _calculateScale();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_card_swiper
 description: This is a Tinder-like card swiper package. It allows you to swipe left, right, up, and down and define your own business logic for each direction.
 homepage: https://github.com/ricardodalarme/flutter_card_swiper
 issue_tracker: https://github.com/ricardodalarme/flutter_card_swiper/issues
-version: 1.2.0
+version: 1.2.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
As I reviewed the code I thought that maybe I made the 'isDisabled' parameter redundant, since it is now the same than disabling both axis. Don't hesitate to tell me if I should completly merge the features or leave it like that
