### PR TITLE
feat: onSwipe method can cancel the swipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.0.0]
+
+- **BREAKING CHANGE**:
+  - CardSwipers onSwipe function now returns <bool?> instead of <void>. I order to restore
+    compatibility it is enough to declare <bool?> as the new return type, no further changes are
+    needed. If onSwipe returns false, the swipe action will now be canceled and the current card
+    will remain on top of the stack.
+
 ## [3.1.0]
 
 - Adds option to set the initial index of the swiper.
@@ -21,7 +29,7 @@
 - Makes CardSwiper a generic of `Widget?`.
 - Adds option to control if the stack should loop or not.
 - **BREAKING CHANGE**:
-  - Now CardSwiper is a stack, meaning that the last item is now the visible item.
+    - Now CardSwiper is a stack, meaning that the last item is now the visible item.
 
 ## [1.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [4.0.0]
 
 - **BREAKING CHANGE**:
-  - CardSwipers onSwipe function now returns <bool?> instead of <void>. I order to restore
+  - CardSwipers onSwipe function now returns <bool?> instead of <void>. In order to restore
     compatibility it is enough to declare <bool?> as the new return type, no further changes are
     needed. If onSwipe returns false, the swipe action will now be canceled and the current card
     will remain on top of the stack.
@@ -29,7 +29,7 @@
 - Makes CardSwiper a generic of `Widget?`.
 - Adds option to control if the stack should loop or not.
 - **BREAKING CHANGE**:
-    - Now CardSwiper is a stack, meaning that the last item is now the visible item.
+  - Now CardSwiper is a stack, meaning that the last item is now the visible item.
 
 ## [1.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 ## [4.0.0]
 
 - **BREAKING CHANGE**:
-  - CardSwipers onSwipe function now returns <bool?> instead of <void>. In order to restore
-    compatibility it is enough to declare <bool?> as the new return type, no further changes are
-    needed. If onSwipe returns false, the swipe action will now be canceled and the current card
-    will remain on top of the stack.
+  - CardSwipers onSwipe function now returns ```<bool>``` instead of ```<void>```. If onSwipe returns ```false```,
+    the swipe action will now be canceled and the current card will remain on top of the stack. 
+    Otherwise, if it returns ```true```, the swipe action will be performed as expected.
 
 ## [3.1.0]
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ class Example extends StatelessWidget {
 | isVerticalSwipingEnabled | true    |   Set to ```false``` if you want your card to move only across the horizontal axis when swiping | false
 | isLoop | true | set to ```true``` if the stack should loop | false
 | onTapDisabled | -     |    Function that get triggered when the swiper is disabled | false
-| onSwipe | -    |    Called with the new index and detected swipe direction when the user swiped | false
+| onSwipe | -    |    Called with the oldIndex, newIndex and detected swipe direction when the user swiped.  If [onSwipe] returns ```false```, the swipe action will be canceled. Otherwise, if it returns ```true```, the swipe action will be performed as expected. | false
 | onEnd | -    |    Called when there is no Widget left to be swiped away | false
 | direction | right    |    Direction in which the card is swiped away when triggered from the outside | false
 | numberOfCardsDisplayed | 2    |   If your widgets in the 'cards' list cause performance issues, you can choose to display more cards at a time to reduce how long the user waits for a card to appear | false 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -76,11 +76,18 @@ class _ExamplePageState extends State<Example> {
     );
   }
 
-  void _onSwipe(
+  bool? _onSwipe(
     int? previousIndex,
     int? currentIndex,
     CardSwiperDirection direction,
   ) {
+    if (currentIndex?.isEven == true && direction == CardSwiperDirection.left ||
+        currentIndex?.isOdd == true && direction == CardSwiperDirection.right) {
+      debugPrint(
+        'the card $currentIndex was swiped to the: ${direction.name}; Oh, and also your action got canceled',
+      );
+      return false;
+    }
     debugPrint(
       'the card $previousIndex was swiped to the ${direction.name}. Now the card $currentIndex is on top',
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -76,7 +76,7 @@ class _ExamplePageState extends State<Example> {
     );
   }
 
-  bool? _onSwipe(
+  bool _onSwipe(
     int? previousIndex,
     int? currentIndex,
     CardSwiperDirection direction,
@@ -88,8 +88,10 @@ class _ExamplePageState extends State<Example> {
       );
       return false;
     }
+
     debugPrint(
       'the card $previousIndex was swiped to the ${direction.name}. Now the card $currentIndex is on top',
     );
+    return true;
   }
 }

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -134,7 +134,9 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper<T>>
   double get _maxAngle => widget.maxAngle * (pi / 180);
 
   int? _currentIndex;
+
   int? get _nextIndex => getValidIndexOffset(1);
+
   bool get _canSwipe => _currentIndex != null && !widget.isDisabled;
 
   @override
@@ -316,8 +318,9 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper<T>>
   void _handleOnSwipe() {
     setState(() {
       if (_swipeType == SwipeType.swipe) {
-        final cancelSwipe =
-            widget.onSwipe?.call(_currentIndex, detectedDirection) == false;
+        final cancelSwipe = widget.onSwipe
+                ?.call(_currentIndex, _nextIndex, detectedDirection) ==
+            false;
 
         if (cancelSwipe) {
           return;

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -311,48 +311,54 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper<T>>
     }
   }
 
+  // handle the onSwipe methode as well as removing the current card from the
+  // stack if onSwipe does not return false
+  void _handleOnSwipe() {
+    setState(() {
+      if (_swipeType == SwipeType.swipe) {
+        final cancelSwipe =
+            widget.onSwipe?.call(_currentIndex, detectedDirection) == false;
+
+        if (cancelSwipe) {
+          return;
+        }
+
+        final previousIndex = _currentIndex;
+        final isLastCard = _currentIndex == widget.cardsCount - 1;
+
+        _currentIndex = _nextIndex;
+        widget.onSwipe?.call(
+          previousIndex,
+          _currentIndex,
+          detectedDirection,
+        );
+
+        if (isLastCard) {
+          widget.onEnd?.call();
+        }
+      }
+    });
+  }
+
+  // reset the card animation
+  void _resetCardAnimation() {
+    setState(() {
+      _animationController.reset();
+      _left = 0;
+      _top = 0;
+      _total = 0;
+      _angle = 0;
+      _scale = widget.scale;
+      _difference = 40;
+      _swipeType = SwipeType.none;
+    });
+  }
+
   //when the status of animation changes
   void _animationStatusListener(AnimationStatus status) {
     if (status == AnimationStatus.completed) {
-      setState(() {
-        if (_swipeType == SwipeType.swipe) {
-          final cancelSwipe = widget.onSwipe?.call(_currentIndex, detectedDirection) == false;
-
-          if (!cancelSwipe) {
-            _stack.removeAt(_currentIndex);
-
-            if (_stack.isEmpty) {
-              widget.onEnd?.call();
-
-              if (widget.isLoop) {
-                _stack.addAll(widget.cards);
-              }
-            }
-          }
-
-          final previousIndex = _currentIndex;
-          final isLastCard = _currentIndex == widget.cardsCount - 1;
-
-          _currentIndex = _nextIndex;
-          widget.onSwipe?.call(
-            previousIndex,
-            _currentIndex,
-            detectedDirection,
-          );
-
-          if (isLastCard) {
-            widget.onEnd?.call();
-          }
-        }
-        _animationController.reset();
-        _left = 0;
-        _top = 0;
-        _total = 0;
-        _angle = 0;
-        _scale = widget.scale;
-        _difference = 40;
-        _swipeType = SwipeType.none;
-      });
+      _handleOnSwipe();
+      _resetCardAnimation();
     }
   }
 

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -38,6 +38,9 @@ class CardSwiper<T extends Widget> extends StatefulWidget {
   final bool isDisabled;
 
   /// function that gets called with the new index and detected swipe direction when the user swiped or swipe is triggered by controller
+  ///
+  /// If [onSwipe] returns false, the swipe action will be canceled and the current card will remain on top of the stack.
+  /// Otherwise, if it returns true, the swipe action will be performed as expected.
   final CardSwiperOnSwipe? onSwipe;
 
   /// function that gets called when there is no widget left to be swiped away
@@ -318,11 +321,11 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper<T>>
   void _handleOnSwipe() {
     setState(() {
       if (_swipeType == SwipeType.swipe) {
-        final cancelSwipe = widget.onSwipe
+        final shouldCancelSwipe = widget.onSwipe
                 ?.call(_currentIndex, _nextIndex, detectedDirection) ==
             false;
 
-        if (cancelSwipe) {
+        if (shouldCancelSwipe) {
           return;
         }
 

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -318,8 +318,16 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper<T>>
         if (_swipeType == SwipeType.swipe) {
           final cancelSwipe = widget.onSwipe?.call(_currentIndex, detectedDirection) == false;
 
-          if (cancelSwipe) {
-            return;
+          if (!cancelSwipe) {
+            _stack.removeAt(_currentIndex);
+
+            if (_stack.isEmpty) {
+              widget.onEnd?.call();
+
+              if (widget.isLoop) {
+                _stack.addAll(widget.cards);
+              }
+            }
           }
 
           final previousIndex = _currentIndex;

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -316,6 +316,12 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper<T>>
     if (status == AnimationStatus.completed) {
       setState(() {
         if (_swipeType == SwipeType.swipe) {
+          final cancelSwipe = widget.onSwipe?.call(_currentIndex, detectedDirection) == false;
+
+          if (cancelSwipe) {
+            return;
+          }
+
           final previousIndex = _currentIndex;
           final isLastCard = _currentIndex == widget.cardsCount - 1;
 

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_card_swiper/src/enums.dart';
 
-typedef CardSwiperOnSwipe = bool? Function(
-    int? previousIndex,
-    int? currentIndex,
+typedef CardSwiperOnSwipe = bool Function(
+  int? previousIndex,
+  int? currentIndex,
   CardSwiperDirection direction,
 );
 

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_card_swiper/src/enums.dart';
 
-typedef CardSwiperOnSwipe = void Function(
-  int? previousIndex,
-  int? currentIndex,
+typedef CardSwiperOnSwipe = bool? Function(
+    int? previousIndex,
+    int? currentIndex,
   CardSwiperDirection direction,
 );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_card_swiper
 description: This is a Tinder-like card swiper package. It allows you to swipe left, right, up, and down and define your own business logic for each direction.
 homepage: https://github.com/ricardodalarme/flutter_card_swiper
 issue_tracker: https://github.com/ricardodalarme/flutter_card_swiper/issues
-version: 3.1.0
+version: 4.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
## Description

Add the possibility to cancel the removal of a card if `onSwipe` returns false. I am using this plugin as an interactive way to answer "yes / no" questions and want the card to just not be removed if the user answers the wrong question.

## Related Issues

- none

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/ricardodalarme/flutter_card_swiper/blob/main/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#version
[following repository CHANGELOG style]:https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#changelog

## Visual reference
