### PR TITLE
Fix Swiping when `isDisabled` is `true` and triggered by the `controller`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.1.3]
+
+- Fix Swiping when `isDisabled` is `true` and triggered by the `controller`.
+
 ## [4.1.2]
 
 - Fixes the `isHorizontalSwipingEnabled` and `isVerticalSwipingEnabled`.

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -391,7 +391,7 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
   }
 
   void _swipe(CardSwiperDirection direction) {
-    if (!_canSwipe) return;
+    if (_currentIndex == null) return;
 
     _swipeType = SwipeType.swipe;
     _detectedDirection = direction;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_card_swiper
 description: This is a Tinder-like card swiper package. It allows you to swipe left, right, up, and down and define your own business logic for each direction.
 homepage: https://github.com/ricardodalarme/flutter_card_swiper
 issue_tracker: https://github.com/ricardodalarme/flutter_card_swiper/issues
-version: 4.1.2
+version: 4.1.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/test/card_swiper_controller_test.dart
+++ b/test/card_swiper_controller_test.dart
@@ -43,281 +43,298 @@ void main() {
       expect(controller.state, CardSwiperState.undo);
     });
 
-    testWidgets('swipe() should swipe the card to the defined direction',
-        (tester) async {
-      final controller = CardSwiperController();
-      var direction = CardSwiperDirection.none;
+    for (final isDisabled in [false, true]) {
+      group('isDisabled=$isDisabled', () {
+        testWidgets('swipe() should swipe the card to the defined direction',
+            (tester) async {
+          final controller = CardSwiperController();
+          var direction = CardSwiperDirection.none;
 
-      await tester.pumpApp(
-        CardSwiper(
-          controller: controller,
-          cardsCount: 10,
-          cardBuilder: genericBuilder,
-          direction: CardSwiperDirection.top,
-          onSwipe: (oldIndex, currentIndex, swipeDirection) {
-            direction = swipeDirection;
-            return true;
-          },
-        ),
-      );
+          await tester.pumpApp(
+            CardSwiper(
+              isDisabled: isDisabled,
+              controller: controller,
+              cardsCount: 10,
+              cardBuilder: genericBuilder,
+              direction: CardSwiperDirection.top,
+              onSwipe: (oldIndex, currentIndex, swipeDirection) {
+                direction = swipeDirection;
+                return true;
+              },
+            ),
+          );
 
-      controller.swipe();
-      await tester.pumpAndSettle();
+          controller.swipe();
+          await tester.pumpAndSettle();
 
-      expect(direction, CardSwiperDirection.top);
-    });
+          expect(direction, CardSwiperDirection.top);
+        });
 
-    testWidgets('swipeLeft() should swipe the card to the left',
-        (tester) async {
-      final controller = CardSwiperController();
-      var direction = CardSwiperDirection.none;
+        testWidgets('swipeLeft() should swipe the card to the left',
+            (tester) async {
+          final controller = CardSwiperController();
+          var direction = CardSwiperDirection.none;
 
-      await tester.pumpApp(
-        CardSwiper(
-          controller: controller,
-          cardsCount: 10,
-          cardBuilder: genericBuilder,
-          direction: CardSwiperDirection.left,
-          onSwipe: (oldIndex, currentIndex, swipeDirection) {
-            direction = swipeDirection;
-            return true;
-          },
-        ),
-      );
+          await tester.pumpApp(
+            CardSwiper(
+              isDisabled: isDisabled,
+              controller: controller,
+              cardsCount: 10,
+              cardBuilder: genericBuilder,
+              direction: CardSwiperDirection.left,
+              onSwipe: (oldIndex, currentIndex, swipeDirection) {
+                direction = swipeDirection;
+                return true;
+              },
+            ),
+          );
 
-      controller.swipeLeft();
-      await tester.pumpAndSettle();
+          controller.swipeLeft();
+          await tester.pumpAndSettle();
 
-      expect(direction, CardSwiperDirection.left);
-    });
+          expect(direction, CardSwiperDirection.left);
+        });
 
-    testWidgets('swipeRight() should swipe the card to the right',
-        (tester) async {
-      final controller = CardSwiperController();
-      var direction = CardSwiperDirection.none;
+        testWidgets('swipeRight() should swipe the card to the right',
+            (tester) async {
+          final controller = CardSwiperController();
+          var direction = CardSwiperDirection.none;
 
-      await tester.pumpApp(
-        CardSwiper(
-          controller: controller,
-          cardsCount: 10,
-          cardBuilder: genericBuilder,
-          onSwipe: (oldIndex, currentIndex, swipeDirection) {
-            direction = swipeDirection;
-            return true;
-          },
-        ),
-      );
+          await tester.pumpApp(
+            CardSwiper(
+              isDisabled: isDisabled,
+              controller: controller,
+              cardsCount: 10,
+              cardBuilder: genericBuilder,
+              onSwipe: (oldIndex, currentIndex, swipeDirection) {
+                direction = swipeDirection;
+                return true;
+              },
+            ),
+          );
 
-      controller.swipeRight();
-      await tester.pumpAndSettle();
+          controller.swipeRight();
+          await tester.pumpAndSettle();
 
-      expect(direction, CardSwiperDirection.right);
-    });
+          expect(direction, CardSwiperDirection.right);
+        });
 
-    testWidgets('swipeTop() should swipe the card to the top', (tester) async {
-      final controller = CardSwiperController();
-      var direction = CardSwiperDirection.none;
+        testWidgets('swipeTop() should swipe the card to the top',
+            (tester) async {
+          final controller = CardSwiperController();
+          var direction = CardSwiperDirection.none;
 
-      await tester.pumpApp(
-        CardSwiper(
-          controller: controller,
-          cardsCount: 10,
-          cardBuilder: genericBuilder,
-          direction: CardSwiperDirection.top,
-          onSwipe: (oldIndex, currentIndex, swipeDirection) {
-            direction = swipeDirection;
-            return true;
-          },
-        ),
-      );
+          await tester.pumpApp(
+            CardSwiper(
+              isDisabled: isDisabled,
+              controller: controller,
+              cardsCount: 10,
+              cardBuilder: genericBuilder,
+              direction: CardSwiperDirection.top,
+              onSwipe: (oldIndex, currentIndex, swipeDirection) {
+                direction = swipeDirection;
+                return true;
+              },
+            ),
+          );
 
-      controller.swipeTop();
-      await tester.pumpAndSettle();
+          controller.swipeTop();
+          await tester.pumpAndSettle();
 
-      expect(direction, CardSwiperDirection.top);
-    });
+          expect(direction, CardSwiperDirection.top);
+        });
 
-    testWidgets('swipeBottom() should swipe the card to the bottom',
-        (tester) async {
-      final controller = CardSwiperController();
-      var direction = CardSwiperDirection.none;
+        testWidgets('swipeBottom() should swipe the card to the bottom',
+            (tester) async {
+          final controller = CardSwiperController();
+          var direction = CardSwiperDirection.none;
 
-      await tester.pumpApp(
-        CardSwiper(
-          controller: controller,
-          cardsCount: 10,
-          cardBuilder: genericBuilder,
-          direction: CardSwiperDirection.bottom,
-          onSwipe: (oldIndex, currentIndex, swipeDirection) {
-            direction = swipeDirection;
-            return true;
-          },
-        ),
-      );
+          await tester.pumpApp(
+            CardSwiper(
+              isDisabled: isDisabled,
+              controller: controller,
+              cardsCount: 10,
+              cardBuilder: genericBuilder,
+              direction: CardSwiperDirection.bottom,
+              onSwipe: (oldIndex, currentIndex, swipeDirection) {
+                direction = swipeDirection;
+                return true;
+              },
+            ),
+          );
 
-      controller.swipeBottom();
-      await tester.pumpAndSettle();
+          controller.swipeBottom();
+          await tester.pumpAndSettle();
 
-      expect(direction, CardSwiperDirection.bottom);
-    });
+          expect(direction, CardSwiperDirection.bottom);
+        });
 
-    group('undo()', () {
-      testWidgets('should undo the last swipe', (tester) async {
-        final controller = CardSwiperController();
+        group('undo()', () {
+          testWidgets('should undo the last swipe', (tester) async {
+            final controller = CardSwiperController();
 
-        await tester.pumpApp(
-          CardSwiper(
-            controller: controller,
-            cardsCount: 10,
-            cardBuilder: genericBuilder,
-          ),
-        );
+            await tester.pumpApp(
+              CardSwiper(
+                isDisabled: isDisabled,
+                controller: controller,
+                cardsCount: 10,
+                cardBuilder: genericBuilder,
+              ),
+            );
 
-        controller.swipe();
-        await tester.pumpAndSettle();
+            controller.swipe();
+            await tester.pumpAndSettle();
 
-        expect(find.card(1), findsOneWidget);
+            expect(find.card(1), findsOneWidget);
 
-        controller.undo();
-        await tester.pumpAndSettle();
+            controller.undo();
+            await tester.pumpAndSettle();
 
-        expect(find.card(0), findsOneWidget);
+            expect(find.card(0), findsOneWidget);
+          });
+
+          testWidgets('should undo the last swipe left', (tester) async {
+            final controller = CardSwiperController();
+            var direction = CardSwiperDirection.none;
+
+            await tester.pumpApp(
+              CardSwiper(
+                isDisabled: isDisabled,
+                controller: controller,
+                cardsCount: 10,
+                cardBuilder: genericBuilder,
+                onUndo: (_, __, swipeDirection) {
+                  direction = swipeDirection;
+                  return true;
+                },
+              ),
+            );
+
+            controller.swipeLeft();
+            await tester.pumpAndSettle();
+
+            expect(find.card(1), findsOneWidget);
+
+            controller.undo();
+            await tester.pumpAndSettle();
+
+            expect(find.card(0), findsOneWidget);
+            expect(direction, CardSwiperDirection.left);
+          });
+
+          testWidgets('should undo the last swipe right', (tester) async {
+            final controller = CardSwiperController();
+            var direction = CardSwiperDirection.none;
+
+            await tester.pumpApp(
+              CardSwiper(
+                isDisabled: isDisabled,
+                controller: controller,
+                cardsCount: 10,
+                cardBuilder: genericBuilder,
+                onUndo: (_, __, swipeDirection) {
+                  direction = swipeDirection;
+                  return true;
+                },
+              ),
+            );
+
+            controller.swipeRight();
+            await tester.pumpAndSettle();
+
+            expect(find.card(1), findsOneWidget);
+
+            controller.undo();
+            await tester.pumpAndSettle();
+
+            expect(find.card(0), findsOneWidget);
+            expect(direction, CardSwiperDirection.right);
+          });
+
+          testWidgets('should undo the last swipe top', (tester) async {
+            final controller = CardSwiperController();
+            var direction = CardSwiperDirection.none;
+
+            await tester.pumpApp(
+              CardSwiper(
+                isDisabled: isDisabled,
+                controller: controller,
+                cardsCount: 10,
+                cardBuilder: genericBuilder,
+                onUndo: (_, __, swipeDirection) {
+                  direction = swipeDirection;
+                  return true;
+                },
+              ),
+            );
+
+            controller.swipeTop();
+            await tester.pumpAndSettle();
+
+            expect(find.card(1), findsOneWidget);
+
+            controller.undo();
+            await tester.pumpAndSettle();
+
+            expect(find.card(0), findsOneWidget);
+            expect(direction, CardSwiperDirection.top);
+          });
+
+          testWidgets('should undo the last swipe bottom', (tester) async {
+            final controller = CardSwiperController();
+            var direction = CardSwiperDirection.none;
+
+            await tester.pumpApp(
+              CardSwiper(
+                isDisabled: isDisabled,
+                controller: controller,
+                cardsCount: 10,
+                cardBuilder: genericBuilder,
+                onUndo: (_, __, swipeDirection) {
+                  direction = swipeDirection;
+                  return true;
+                },
+              ),
+            );
+
+            controller.swipeBottom();
+            await tester.pumpAndSettle();
+
+            expect(find.card(1), findsOneWidget);
+
+            controller.undo();
+            await tester.pumpAndSettle();
+
+            expect(find.card(0), findsOneWidget);
+            expect(direction, CardSwiperDirection.bottom);
+          });
+
+          testWidgets('should not undo if onUndo returns false',
+              (tester) async {
+            final controller = CardSwiperController();
+
+            await tester.pumpApp(
+              CardSwiper(
+                isDisabled: isDisabled,
+                controller: controller,
+                cardsCount: 10,
+                cardBuilder: genericBuilder,
+                onUndo: (_, __, swipeDirection) {
+                  return false;
+                },
+              ),
+            );
+
+            controller.swipe();
+            await tester.pumpAndSettle();
+
+            controller.undo();
+            await tester.pumpAndSettle();
+
+            expect(find.card(0), findsNothing);
+          });
+        });
       });
-
-      testWidgets('should undo the last swipe left', (tester) async {
-        final controller = CardSwiperController();
-        var direction = CardSwiperDirection.none;
-
-        await tester.pumpApp(
-          CardSwiper(
-            controller: controller,
-            cardsCount: 10,
-            cardBuilder: genericBuilder,
-            onUndo: (_, __, swipeDirection) {
-              direction = swipeDirection;
-              return true;
-            },
-          ),
-        );
-
-        controller.swipeLeft();
-        await tester.pumpAndSettle();
-
-        expect(find.card(1), findsOneWidget);
-
-        controller.undo();
-        await tester.pumpAndSettle();
-
-        expect(find.card(0), findsOneWidget);
-        expect(direction, CardSwiperDirection.left);
-      });
-
-      testWidgets('should undo the last swipe right', (tester) async {
-        final controller = CardSwiperController();
-        var direction = CardSwiperDirection.none;
-
-        await tester.pumpApp(
-          CardSwiper(
-            controller: controller,
-            cardsCount: 10,
-            cardBuilder: genericBuilder,
-            onUndo: (_, __, swipeDirection) {
-              direction = swipeDirection;
-              return true;
-            },
-          ),
-        );
-
-        controller.swipeRight();
-        await tester.pumpAndSettle();
-
-        expect(find.card(1), findsOneWidget);
-
-        controller.undo();
-        await tester.pumpAndSettle();
-
-        expect(find.card(0), findsOneWidget);
-        expect(direction, CardSwiperDirection.right);
-      });
-
-      testWidgets('should undo the last swipe top', (tester) async {
-        final controller = CardSwiperController();
-        var direction = CardSwiperDirection.none;
-
-        await tester.pumpApp(
-          CardSwiper(
-            controller: controller,
-            cardsCount: 10,
-            cardBuilder: genericBuilder,
-            onUndo: (_, __, swipeDirection) {
-              direction = swipeDirection;
-              return true;
-            },
-          ),
-        );
-
-        controller.swipeTop();
-        await tester.pumpAndSettle();
-
-        expect(find.card(1), findsOneWidget);
-
-        controller.undo();
-        await tester.pumpAndSettle();
-
-        expect(find.card(0), findsOneWidget);
-        expect(direction, CardSwiperDirection.top);
-      });
-
-      testWidgets('should undo the last swipe bottom', (tester) async {
-        final controller = CardSwiperController();
-        var direction = CardSwiperDirection.none;
-
-        await tester.pumpApp(
-          CardSwiper(
-            controller: controller,
-            cardsCount: 10,
-            cardBuilder: genericBuilder,
-            onUndo: (_, __, swipeDirection) {
-              direction = swipeDirection;
-              return true;
-            },
-          ),
-        );
-
-        controller.swipeBottom();
-        await tester.pumpAndSettle();
-
-        expect(find.card(1), findsOneWidget);
-
-        controller.undo();
-        await tester.pumpAndSettle();
-
-        expect(find.card(0), findsOneWidget);
-        expect(direction, CardSwiperDirection.bottom);
-      });
-
-      testWidgets('should not undo if onUndo returns false', (tester) async {
-        final controller = CardSwiperController();
-
-        await tester.pumpApp(
-          CardSwiper(
-            controller: controller,
-            cardsCount: 10,
-            cardBuilder: genericBuilder,
-            onUndo: (_, __, swipeDirection) {
-              return false;
-            },
-          ),
-        );
-
-        controller.swipe();
-        await tester.pumpAndSettle();
-
-        controller.undo();
-        await tester.pumpAndSettle();
-
-        expect(find.card(0), findsNothing);
-      });
-    });
+    }
   });
 }


### PR DESCRIPTION


## Description
https://github.com/ricardodalarme/flutter_card_swiper/blob/75d8ebe903738844774c05a1daabf80f5fa07855/lib/src/card_swiper.dart#L63-L68

> If `true`, swiping is disabled, except when triggered by the [controller].

In actuality, it is also disabled when triggered from the controller.

## Related Issues

- Closes #(add issue number)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/ricardodalarme/flutter_card_swiper/blob/main/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#version
[following repository CHANGELOG style]:https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#changelog

## Visual reference

<!--- Please include screenshots, gifs or recordings  -->
<!--- For example: if this is a bug fix, provide before and after screenshots -->
