### PR TITLE
fix: remove controller dispose and add removeListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+- **BREAKING CHANGE**:
+  - `CardSwiperController` is no longer disposed by `CardSwiper`, but who created it must dispose it.
+
 ## [4.1.3]
 
 - Fix Swiping when `isDisabled` is `true` and triggered by the `controller`.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,6 +27,12 @@ class _ExamplePageState extends State<Example> {
   final cards = candidates.map((candidate) => ExampleCard(candidate)).toList();
 
   @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -201,7 +201,7 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
   void dispose() {
     super.dispose();
     _animationController.dispose();
-    widget.controller?.dispose();
+    widget.controller?.removeListener(_controllerListener);
   }
 
   @override


### PR DESCRIPTION
## Description

I removed the dispose of `CardSwiperController`, the dispose must always be made where the controller is instantiated.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/ricardodalarme/flutter_card_swiper/blob/main/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#version
[following repository CHANGELOG style]:https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#changelog

