### PR TITLE
Support for nagative back card offset and minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.0.1]
+
+- Adds support for negative back card offset.
+- Fix only 2 cards displayed even when numberOfCardsDisplayed param is greater than 2.
+
 ## [5.0.0]
 
 - Adds option to customize the back card offset.

--- a/lib/src/card_animation.dart
+++ b/lib/src/card_animation.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_card_swiper/flutter_card_swiper.dart';
@@ -74,11 +75,9 @@ class CardAnimation {
   }
 
   void updateScale() {
-    if (scale.isBetween(initialScale, 1.0)) {
-      scale = (total > 0)
-          ? initialScale + (total / 5000)
-          : initialScale + -(total / 5000);
-    }
+    scale = (total > 0)
+        ? clampDouble(initialScale + (total / 5000), initialScale, 1.0)
+        : clampDouble(initialScale - (total / 5000), initialScale, 1.0);
   }
 
   void updateDifference() {

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -57,6 +57,12 @@ class CardSwiper extends StatefulWidget {
 
   /// The scale of the card that is behind the front card.
   ///
+  /// The [scale] and [backCardOffset] both impact the positions of the back cards.
+  /// In order to keep the back card position same after changing the [scale],
+  /// the [backCardOffset] should also be adjusted.
+  /// * As a rough rule of thumb, 0.1 change in [scale] effects an
+  /// [backCardOffset] of ~35px.
+  ///
   /// Must be between 0 and 1. Defaults to 0.9.
   final double scale;
 
@@ -107,6 +113,11 @@ class CardSwiper extends StatefulWidget {
   final CardSwiperOnUndo? onUndo;
 
   /// The offset of the back card from the front card.
+  ///
+  /// In order to keep the back card position same after changing the [backCardOffset],
+  /// the [scale] should also be adjusted.
+  /// * As a rough rule of thumb, 35px change in [backCardOffset] effects a
+  /// [scale] change of 0.1.
   ///
   /// Must be a positive value. Defaults to Offset(0, 40).
   final Offset backCardOffset;

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -1,5 +1,5 @@
 import 'dart:collection';
-import 'dart:math';
+import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_card_swiper/src/card_animation.dart';
@@ -157,10 +157,6 @@ class CardSwiper extends StatefulWidget {
           initialIndex >= 0 && initialIndex < cardsCount,
           'initialIndex must be between 0 and [cardsCount]',
         ),
-        assert(
-          backCardOffset >= Offset.zero,
-          'backCardOffset must be a positive value',
-        ),
         super(key: key);
 
   @override
@@ -227,9 +223,7 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
                 clipBehavior: Clip.none,
                 fit: StackFit.expand,
                 children: List.generate(numberOfCardsOnScreen(), (index) {
-                  if (index == 0) {
-                    return _frontItem(constraints);
-                  }
+                  if (index == 0) return _frontItem(constraints);
 
                   return _backItem(constraints, index);
                 }).reversed.toList(),
@@ -287,15 +281,15 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
     );
   }
 
-  Widget _backItem(BoxConstraints constraints, int offset) {
+  Widget _backItem(BoxConstraints constraints, int index) {
     return Positioned(
-      top: _cardAnimation.difference.dy * offset,
-      left: _cardAnimation.difference.dx * offset,
+      top: (widget.backCardOffset.dy * index) - _cardAnimation.difference.dy,
+      left: (widget.backCardOffset.dx * index) - _cardAnimation.difference.dx,
       child: Transform.scale(
-        scale: _cardAnimation.scale - ((1 - widget.scale) * (offset - 1)),
+        scale: _cardAnimation.scale - ((1 - widget.scale) * (index - 1)),
         child: ConstrainedBox(
           constraints: constraints,
-          child: widget.cardBuilder(context, getValidIndexOffset(offset)!),
+          child: widget.cardBuilder(context, getValidIndexOffset(index)!),
         ),
       ),
     );
@@ -426,7 +420,7 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
       return 0;
     }
 
-    return min(
+    return math.min(
       widget.numberOfCardsDisplayed,
       widget.cardsCount - _currentIndex!,
     );

--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -230,9 +230,7 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
                   if (index == 0) {
                     return _frontItem(constraints);
                   }
-                  if (index == 1) {
-                    return _secondItem(constraints);
-                  }
+
                   return _backItem(constraints, index);
                 }).reversed.toList(),
               );
@@ -289,32 +287,15 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
     );
   }
 
-  Widget _secondItem(BoxConstraints constraints) {
-    return Positioned(
-      top: _cardAnimation.difference.dy,
-      left: _cardAnimation.difference.dx,
-      child: Transform.scale(
-        scale: _cardAnimation.scale,
-        child: ConstrainedBox(
-          constraints: constraints,
-          child: widget.cardBuilder(context, _nextIndex!),
-        ),
-      ),
-    );
-  }
-
   Widget _backItem(BoxConstraints constraints, int offset) {
     return Positioned(
-      top: widget.backCardOffset.dy,
-      left: widget.backCardOffset.dx,
+      top: _cardAnimation.difference.dy * offset,
+      left: _cardAnimation.difference.dx * offset,
       child: Transform.scale(
-        scale: widget.scale,
+        scale: _cardAnimation.scale - ((1 - widget.scale) * (offset - 1)),
         child: ConstrainedBox(
           constraints: constraints,
-          child: widget.cardBuilder(
-            context,
-            getValidIndexOffset(offset)!,
-          ),
+          child: widget.cardBuilder(context, getValidIndexOffset(offset)!),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_card_swiper
 description: This is a Tinder-like card swiper package. It allows you to swipe left, right, up, and down and define your own business logic for each direction.
 homepage: https://github.com/ricardodalarme/flutter_card_swiper
 issue_tracker: https://github.com/ricardodalarme/flutter_card_swiper/issues
-version: 5.0.0
+version: 5.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
## Description

- Adds support for negative back card offset.
   - Assertion for negative offset is no longer required 
- Fixes only 2 cards displayed even when numberOfCardsDisplayed param is greater than 2.
- Fixes card does not scale down after reaching 1.0 scale.

## Related Issues

- None

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/ricardodalarme/flutter_card_swiper/blob/main/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#version
[following repository CHANGELOG style]:https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#changelog

## Visual reference

![Negative back card offset demo | Offset(-4,-45)](https://media.giphy.com/media/nZ01EfrOicPg1XSvB3/giphy.gif)