### PR TITLE
Fix: cannot access context in `onSwipe` when no cards left then "destroy" the widget tree

### DIFF
--- a/lib/src/card_swiper.dart
+++ b/lib/src/card_swiper.dart
@@ -248,9 +248,9 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
 
   @override
   void dispose() {
-    super.dispose();
     _animationController.dispose();
     widget.controller?.removeListener(_controllerListener);
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
## Description

Step to Reproduce Issue:
1. Create a StatefulWidget for a page:

```dart
class FirstPage extends StatefulWidget {
  ...
}

class _FirstPageState extends State<FirstPage> {
  final List<Model> datas = [
    ...
  ];

  int currentIndex = 0;

  @override
  Widget build(BuildContext context) {
    return currentIndex == (datas.length - 1)
      ? NoDataLeft() // Another widget to show no data message
      : MyCards(
          datas: datas,
          onLiked: (index) {
            currentIndex = index;
            setState(() {});
          },
        );
    }
}
```

2. Create a single common widget

```dart
class MyCards extends StatelessWidget {
  final List<Model> datas;
  final ValueChanged<int> onLiked;

  const MyCards({super.key, required this.datas, required this.onLiked});

  @override
  Widget build(BuildContext context) {
    return CardSwiper(
      onSwipe: (previousIndex, currentIndex, direction) {
        // If the last card swiped and disposed, this block cannot access context's inheritance anymore
        // For example:
        context.read<MyProvider>();
      },
      cardsCount: widget.items.length,
      cardBuilder: (context, index, xPercent, yPercent) {
        return MyCardItemView(
          onLiked: () {
            onLiked(index);
          },
        );
      },
    );
  }
}
```

Error will appears and points to `card_swiper.dart` line 251.

This PR will fix the issue, just to arrange order when to call `super.dispose()`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/ricardodalarme/flutter_card_swiper/blob/main/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#version
[following repository CHANGELOG style]:https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#changelog

## Visual reference

<!--- Please include screenshots, gifs or recordings  -->
<!--- For example: if this is a bug fix, provide before and after screenshots -->
