### PR TITLE
fix: prevent early dispose of CardSwiperController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [7.0.1]
+
+- Prevents `CardSwiperController` to be disposed by `CardSwiper`.
 
 ## [7.0.0]
 

--- a/lib/src/widget/card_swiper_state.dart
+++ b/lib/src/widget/card_swiper_state.dart
@@ -65,7 +65,6 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
   @override
   void dispose() {
     _animationController.dispose();
-    widget.controller?.dispose();
     super.dispose();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_card_swiper
 description: This is a Tinder-like card swiper package. It allows you to swipe left, right, up, and down and define your own business logic for each direction.
 homepage: https://github.com/ricardodalarme/flutter_card_swiper
 issue_tracker: https://github.com/ricardodalarme/flutter_card_swiper/issues
-version: 7.0.0
+version: 7.0.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
First of all, thanks for great package 🚀 

## Description

I was facing the issue that the `CardSwiperController` I saved in my state stopped working when the `CardSwiper` in the child widget was rebuilt. When calling a method upon the `CardSwiperController` I received an error saying that the underlying stream was closed. 

When investigating the code I discovered that `CardSwiper` is calling `dispose` on the `CardSwiperController` that was passed in as a parameter leading to the closing of the stream. My belief is that it's not the responsibility of `CardSwiper` to dispose of `CardSwiperController` since this widget did not create the controller. Instead it should be disposed by the parent widget that is passing `CardSwiperController` to `CardSwiper`, as it's done in `example/lib/main.dart`.

This commit fixed the issue for me. 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/ricardodalarme/flutter_card_swiper/blob/main/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#version
[following repository CHANGELOG style]:https://github.com/ricardodalarme/flutter_card_swiper/blob/chore/add-a-contributing-guide/CONTRIBUTING.md#changelog
