### PR TITLE
Track controller stream subscription and cancel on dispose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [7.0.2]
+
+- Tracks `StreamSubscription<ControllerEvent>` given `widget.controller`, and calls `cancel` on dispose.
+
 ## [7.0.1]
 
 - Prevents `CardSwiperController` to be disposed by `CardSwiper`.

--- a/lib/src/widget/card_swiper.dart
+++ b/lib/src/widget/card_swiper.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'dart:math' as math;
 

--- a/lib/src/widget/card_swiper_state.dart
+++ b/lib/src/widget/card_swiper_state.dart
@@ -189,7 +189,8 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
   Future<void> _handleCompleteSwipe() async {
     final isLastCard = _currentIndex! == widget.cardsCount - 1;
     final shouldCancelSwipe = await widget.onSwipe
-            ?.call(_currentIndex!, _nextIndex, _detectedDirection) == false;
+            ?.call(_currentIndex!, _nextIndex, _detectedDirection) ==
+        false;
 
     if (shouldCancelSwipe) {
       return;

--- a/lib/src/widget/card_swiper_state.dart
+++ b/lib/src/widget/card_swiper_state.dart
@@ -1,7 +1,6 @@
 part of 'card_swiper.dart';
 
-class _CardSwiperState<T extends Widget> extends State<CardSwiper>
-    with SingleTickerProviderStateMixin {
+class _CardSwiperState<T extends Widget> extends State<CardSwiper> with SingleTickerProviderStateMixin {
   late CardAnimation _cardAnimation;
   late AnimationController _animationController;
 
@@ -20,13 +19,15 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
 
   bool get _canSwipe => _currentIndex != null && !widget.isDisabled;
 
+  StreamSubscription<ControllerEvent>? controllerSubscription;
+
   @override
   void initState() {
     super.initState();
 
     _undoableIndex.state = widget.initialIndex;
 
-    widget.controller?.events.listen(_controllerListener);
+    controllerSubscription = widget.controller?.events.listen(_controllerListener);
 
     _animationController = AnimationController(
       duration: widget.duration,
@@ -58,13 +59,13 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
         _detectedVerticalDirection = direction;
     }
 
-    widget.onSwipeDirectionChange
-        ?.call(_detectedHorizontalDirection, _detectedVerticalDirection);
+    widget.onSwipeDirectionChange?.call(_detectedHorizontalDirection, _detectedVerticalDirection);
   }
 
   @override
   void dispose() {
     _animationController.dispose();
+    controllerSubscription?.cancel();
     super.dispose();
   }
 
@@ -185,9 +186,7 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
 
   Future<void> _handleCompleteSwipe() async {
     final isLastCard = _currentIndex! == widget.cardsCount - 1;
-    final shouldCancelSwipe = await widget.onSwipe
-            ?.call(_currentIndex!, _nextIndex, _detectedDirection) ==
-        false;
+    final shouldCancelSwipe = await widget.onSwipe?.call(_currentIndex!, _nextIndex, _detectedDirection) == false;
 
     if (shouldCancelSwipe) {
       return;
@@ -224,14 +223,10 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
 
   CardSwiperDirection _getEndAnimationDirection() {
     if (_cardAnimation.left.abs() > widget.threshold) {
-      return _cardAnimation.left.isNegative
-          ? CardSwiperDirection.left
-          : CardSwiperDirection.right;
+      return _cardAnimation.left.isNegative ? CardSwiperDirection.left : CardSwiperDirection.right;
     }
     if (_cardAnimation.top.abs() > widget.threshold) {
-      return _cardAnimation.top.isNegative
-          ? CardSwiperDirection.top
-          : CardSwiperDirection.bottom;
+      return _cardAnimation.top.isNegative ? CardSwiperDirection.top : CardSwiperDirection.bottom;
     }
     return CardSwiperDirection.none;
   }

--- a/lib/src/widget/card_swiper_state.dart
+++ b/lib/src/widget/card_swiper_state.dart
@@ -1,6 +1,7 @@
 part of 'card_swiper.dart';
 
-class _CardSwiperState<T extends Widget> extends State<CardSwiper> with SingleTickerProviderStateMixin {
+class _CardSwiperState<T extends Widget> extends State<CardSwiper>
+    with SingleTickerProviderStateMixin {
   late CardAnimation _cardAnimation;
   late AnimationController _animationController;
 
@@ -59,7 +60,8 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper> with SingleTi
         _detectedVerticalDirection = direction;
     }
 
-    widget.onSwipeDirectionChange?.call(_detectedHorizontalDirection, _detectedVerticalDirection);
+    widget.onSwipeDirectionChange
+        ?.call(_detectedHorizontalDirection, _detectedVerticalDirection);
   }
 
   @override
@@ -186,7 +188,8 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper> with SingleTi
 
   Future<void> _handleCompleteSwipe() async {
     final isLastCard = _currentIndex! == widget.cardsCount - 1;
-    final shouldCancelSwipe = await widget.onSwipe?.call(_currentIndex!, _nextIndex, _detectedDirection) == false;
+    final shouldCancelSwipe = await widget.onSwipe
+            ?.call(_currentIndex!, _nextIndex, _detectedDirection) == false;
 
     if (shouldCancelSwipe) {
       return;
@@ -223,10 +226,14 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper> with SingleTi
 
   CardSwiperDirection _getEndAnimationDirection() {
     if (_cardAnimation.left.abs() > widget.threshold) {
-      return _cardAnimation.left.isNegative ? CardSwiperDirection.left : CardSwiperDirection.right;
+      return _cardAnimation.left.isNegative
+          ? CardSwiperDirection.left
+          : CardSwiperDirection.right;
     }
     if (_cardAnimation.top.abs() > widget.threshold) {
-      return _cardAnimation.top.isNegative ? CardSwiperDirection.top : CardSwiperDirection.bottom;
+      return _cardAnimation.top.isNegative
+          ? CardSwiperDirection.top
+          : CardSwiperDirection.bottom;
     }
     return CardSwiperDirection.none;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_card_swiper
 description: This is a Tinder-like card swiper package. It allows you to swipe left, right, up, and down and define your own business logic for each direction.
 homepage: https://github.com/ricardodalarme/flutter_card_swiper
 issue_tracker: https://github.com/ricardodalarme/flutter_card_swiper/issues
-version: 7.0.1
+version: 7.0.2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Description

```
// init:
controllerSubscription = widget.controller?.events.listen(_controllerListener);

// dispose:
controllerSubscription?.cancel();
```

## Related Issues

Fixes:
```
Unhandled Exception: This widget has been unmounted, so the State no longer has a context (and should be considered defunct).
Consider canceling any active work during "dispose" or using the "mounted" getter to determine if the State is still active.
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [-] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.



## Visual reference

No change
