### PR TITLE
Feature/optional undo swipe

### DIFF
--- a/lib/src/widget/card_swiper.dart
+++ b/lib/src/widget/card_swiper.dart
@@ -122,6 +122,11 @@ class CardSwiper extends StatefulWidget {
   /// Must be a positive value. Defaults to Offset(0, 40).
   final Offset backCardOffset;
 
+  /// If true, the previous card will be shown in the background when swiping right,
+  /// and the swipe right action will trigger an undo.
+  /// Defaults to false.
+  final bool showBackCardOnUndo;
+
   const CardSwiper({
     required this.cardBuilder,
     required this.cardsCount,
@@ -142,6 +147,7 @@ class CardSwiper extends StatefulWidget {
     this.numberOfCardsDisplayed = 2,
     this.onUndo,
     this.backCardOffset = const Offset(0, 40),
+    this.showBackCardOnUndo = false,
     super.key,
   })  : assert(
           maxAngle >= 0 && maxAngle <= 360,

--- a/lib/src/widget/card_swiper.dart
+++ b/lib/src/widget/card_swiper.dart
@@ -124,7 +124,6 @@ class CardSwiper extends StatefulWidget {
 
   /// If true, the previous card will be shown in the background when swiping right,
   /// and the swipe right action will trigger an undo.
-  /// Defaults to false.
   final bool showBackCardOnUndo;
 
   const CardSwiper({

--- a/lib/src/widget/card_swiper_state.dart
+++ b/lib/src/widget/card_swiper_state.dart
@@ -1,6 +1,7 @@
 part of 'card_swiper.dart';
 
-class _CardSwiperState<T extends Widget> extends State<CardSwiper> with SingleTickerProviderStateMixin {
+class _CardSwiperState<T extends Widget> extends State<CardSwiper>
+    with SingleTickerProviderStateMixin {
   late CardAnimation _cardAnimation;
   late AnimationController _animationController;
 
@@ -29,7 +30,8 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper> with SingleTi
 
     _undoableIndex.state = widget.initialIndex;
 
-    controllerSubscription = widget.controller?.events.listen(_controllerListener);
+    controllerSubscription =
+        widget.controller?.events.listen(_controllerListener);
 
     _animationController = AnimationController(
       duration: widget.duration,
@@ -61,7 +63,8 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper> with SingleTi
         _detectedVerticalDirection = direction;
     }
 
-    widget.onSwipeDirectionChange?.call(_detectedHorizontalDirection, _detectedVerticalDirection);
+    widget.onSwipeDirectionChange
+        ?.call(_detectedHorizontalDirection, _detectedVerticalDirection);
   }
 
   @override
@@ -210,7 +213,9 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper> with SingleTi
 
   Future<void> _handleCompleteSwipe() async {
     final isLastCard = _currentIndex! == widget.cardsCount - 1;
-    final shouldCancelSwipe = await widget.onSwipe?.call(_currentIndex!, _nextIndex, _detectedDirection) == false;
+    final shouldCancelSwipe = await widget.onSwipe
+            ?.call(_currentIndex!, _nextIndex, _detectedDirection) ==
+        false;
 
     if (shouldCancelSwipe) {
       return;
@@ -250,10 +255,14 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper> with SingleTi
 
   CardSwiperDirection _getEndAnimationDirection() {
     if (_cardAnimation.left.abs() > widget.threshold) {
-      return _cardAnimation.left.isNegative ? CardSwiperDirection.left : CardSwiperDirection.right;
+      return _cardAnimation.left.isNegative
+          ? CardSwiperDirection.left
+          : CardSwiperDirection.right;
     }
     if (_cardAnimation.top.abs() > widget.threshold) {
-      return _cardAnimation.top.isNegative ? CardSwiperDirection.top : CardSwiperDirection.bottom;
+      return _cardAnimation.top.isNegative
+          ? CardSwiperDirection.top
+          : CardSwiperDirection.bottom;
     }
     return CardSwiperDirection.none;
   }


### PR DESCRIPTION
This commit introduces a new optional feature that enhances the swiper's flexibility and provides a more intuitive user experience for looping carousels.

Currently, the undo action fails when triggered on the first card (index 0) in a looping swiper, as there is no previous state in the history. Additionally, the background card is always the next card in the stack, which can be visually confusing when a right swipe is configured to act as an "undo."

This feature, controlled by the new showBackCardOnUndo boolean property, addresses these issues by:

Enabling True Looping Undo: When showBackCardOnUndo is true and a user swipes right on the first card, the swiper now correctly loops to the last card in the stack with a proper undo animation.

Providing Dynamic Backgrounds: During a right swipe, the swiper will now display the previous card in the background, creating a more logical and visually consistent interaction. During a left swipe, it retains the default behavior of showing the next card.

Ensuring Backward Compatibility: The feature is disabled by default (showBackCardOnUndo: false), so there are no breaking changes for existing users of the package.

This enhancement makes the CardSwiper more powerful for developers looking to implement advanced and non-linear navigation patterns.