### PR TITLE
fix: add mounted check before _reset() to prevent setState after dispose

### DIFF
--- a/lib/src/widget/card_swiper_state.dart
+++ b/lib/src/widget/card_swiper_state.dart
@@ -222,7 +222,7 @@ class _CardSwiperState<T extends Widget> extends State<CardSwiper>
           break;
       }
 
-      _reset();
+      if (mounted) _reset();
     }
   }
 


### PR DESCRIPTION
## Problem

`_animationStatusListener` is an `async` function that `await`s `_handleCompleteSwipe()`, which in turn `await`s the user-provided `onSwipe` callback. During this async gap, the `CardSwiper` widget can be removed from the widget tree (e.g., when all cards are swiped and the parent rebuilds to show an empty state, or when the user navigates away).

When this happens, `_CardSwiperState` is disposed, but the async continuation of `_animationStatusListener` still runs and calls `_reset()`, which calls `setState()` on the now-disposed state — causing an unhandled exception:

```
Unhandled Exception: setState() called after dispose(): _CardSwiperState<Widget>#xxxxx
(lifecycle state: defunct, not mounted, ticker inactive)
```

## Fix

Guard `_reset()` with a `mounted` check, consistent with Flutter best practices for async `State` methods.

```dart
// Before
_reset();

// After
if (mounted) _reset();
```

## Reproduction

1. Use `CardSwiper` with an async `onSwipe` callback (e.g., one that makes a network request)
2. Swipe the last card
3. Observe the unhandled exception in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)